### PR TITLE
set node v4.1.2 for camo support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,11 @@ FROM base/archlinux
 MAINTAINER Paolo Galeone <nessuno@nerdz.eu>
 
 RUN sed -i -e 's#https://mirrors\.kernel\.org#http://mirror.clibre.uqam.ca#g' /etc/pacman.d/mirrorlist && \
-        pacman -Sy git nodejs --noconfirm &&  \
+        pacman -Sy wget ca-certificates git --noconfirm &&  \
         useradd -m -s /bin/bash camo
+
+RUN wget https://nodejs.org/dist/v4.1.2/node-v4.1.2-linux-x64.tar.gz && \
+    gunzip node-v4.1.2-linux-x64.tar.gz && tar -xvf node-v4.1.2-linux-x64.tar
 
 EXPOSE 8081
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 camo:
-    #build: .
-    image: nerdzeu/docker-camo
+    build: .
+    #image: nerdzeu/docker-camo
     ports:
         - "8081:8081"
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 camo:
-    build: .
-    #image: nerdzeu/docker-camo
+    #build: .
+    image: nerdzeu/docker-camo
     ports:
         - "8081:8081"
     volumes:

--- a/startup.sh
+++ b/startup.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+export PATH="node-v4.1.2-linux-x64/bin:$PATH"
+
 if [ ! -d /home/camo/camo ]; then
     cd /home/camo
     git clone --recursive https://github.com/atmos/camo
@@ -8,5 +10,5 @@ chown -R camo:camo /home/camo
 if [ -f /home/camo/env ]; then
     source /home/camo/env 
 fi
-
+node -v
 node /home/camo/camo/server.js


### PR DESCRIPTION
It seems that with previous versions of node (releases 4.0-4.1.1) broke camo: if a certificate in the chain is missing, camo would crash as shown below

```
camo_1     | --------------------------------------------
camo_1     | { type: 'query',
camo_1     |   url: '/e6594541e35677fa30a2eed8ba94f15b3b6535d4?url=https%3A%2F%2Fpls.cry.moe%2FzJL5vaMy.jpg',
camo_1     |   headers: 
camo_1     |    { connection: 'upgrade',
camo_1     |      host: 'camo.<otherhost>',
camo_1     |      'x-forwarded-proto': 'https',
camo_1     |      'x-forwarded-for': '87.0.125.34',
camo_1     |      'x-forwarded-port': '443',
camo_1     |      'x-request-start': '1443977498.770',
camo_1     |      'user-agent': 'Mozilla/5.0 (X11; Linux x86_64; rv:41.0) Gecko/20100101 Firefox/41.0',
camo_1     |      accept: 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
camo_1     |      'accept-language': 'en-US,en;q=0.5',
camo_1     |      'accept-encoding': 'gzip, deflate',
camo_1     |      dnt: '1' },
camo_1     |   dest: 'https://<somehost>/zJL5vaMy.jpg',
camo_1     |   digest: 'e6594541e35677fa30a2eed8ba94f15b3b6535d4' }
camo_1     | --------------------------------------------
camo_1     | --------------------------------------------
camo_1     | { Via: 'Camo Asset Proxy 2.3.0',
camo_1     |   'User-Agent': 'Camo Asset Proxy 2.3.0',
camo_1     |   Accept: 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
camo_1     |   'Accept-Encoding': 'gzip, deflate',
camo_1     |   'X-Frame-Options': 'deny',
camo_1     |   'X-XSS-Protection': '1; mode=block',
camo_1     |   'X-Content-Type-Options': 'nosniff',
camo_1     |   'Content-Security-Policy': 'default-src \'none\'; img-src data:; style-src \'unsafe-inline\'',
camo_1     |   host: '<somehost>' }
camo_1     | --------------------------------------------
camo_1     | node: symbol lookup error: node: undefined symbol: SSL_set_cert_cb
docker_camo_1 exited with code 127
Gracefully stopping... (press Ctrl+C again to force)
```

if camo is run on node 4.1.2, given the same URL as the previous example, it does not break but just spits some useful errors: an example follows

```
camo_1     | [2015-10-05T20:13:48.512Z] Client Request error Error: unable to verify the first certificate
camo_1     |     at Error (native)
camo_1     |     at TLSSocket.<anonymous> (_tls_wrap.js:1000:38)
camo_1     |     at emitNone (events.js:67:13)
camo_1     |     at TLSSocket.emit (events.js:166:7)
camo_1     |     at TLSSocket._finishInit (_tls_wrap.js:567:8): https://<somehost>/zJL5vaMy.jpg
```
